### PR TITLE
Swap Meteor.settings private variable

### DIFF
--- a/server/modules/set-environment-variables.js
+++ b/server/modules/set-environment-variables.js
@@ -1,6 +1,6 @@
 let setEnvironmentVariables = () => {
   if ( Meteor.settings.private ) {
-    process.env.MAIL_URL = Meteor.settings.private.MAIL_URL;
+    Meteor.settings.private.MAIL_URL = process.env.MAIL_URL;
   }
 };
 


### PR DESCRIPTION
On line 3, we need to *set* the private Meteor MAIL_URL variable to whatever is stored in our local environment. We store keys inside our .bashrc or .zshrc file so those important keys, tokens, etc aren't exposed to Git. When the app initializes and hits this file, we store the value of MAIL_URL from our local machine to the Meteor instance running. Sorry about the extra work regarding this!