### PR TITLE
use of alanning:roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 settings-production.json
 npm-debug.log
+
+.idea/.name

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -34,3 +34,4 @@ reactive-var
 reactive-dict
 aldeed:collection2
 tracker
+alanning:roles

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,6 @@
 accounts-base@1.2.2
 accounts-password@1.1.4
+alanning:roles@1.2.14
 aldeed:collection2@2.6.1
 aldeed:simple-schema@1.3.3
 audit-argument-checks@1.0.4

--- a/both/methods/roles/roles.js
+++ b/both/methods/roles/roles.js
@@ -1,0 +1,9 @@
+Meteor.methods({
+  addUserToRole: function ( userId, role ) {
+  	check( userId, String );
+  	check( role, String );
+  	if ( !Roles.userIsInRole( userId, role ) ) {
+    	Roles.addUsersToRoles( userId, role );
+    }
+  },
+});

--- a/both/routes/admin.js
+++ b/both/routes/admin.js
@@ -1,0 +1,10 @@
+const adminRoutes = FlowRouter.group({
+  name: 'admin'
+});
+
+adminRoutes.route( '/settings', {
+  name: 'settings',
+  action() {
+    BlazeLayout.render( 'default', { yield: 'settings' } );
+  }
+});

--- a/client/helpers/roles.js
+++ b/client/helpers/roles.js
@@ -1,0 +1,6 @@
+Tracker.autorun( function () {
+  let userId = Meteor.userId();
+  if ( userId && !Roles.userIsInRole( userId, 'user' ) ) {
+    Meteor.call( 'addUserToRole', userId, 'user' );
+  }
+});

--- a/client/helpers/roles.js
+++ b/client/helpers/roles.js
@@ -1,6 +1,0 @@
-Tracker.autorun( function () {
-  let userId = Meteor.userId();
-  if ( userId && !Roles.userIsInRole( userId, 'user' ) ) {
-    Meteor.call( 'addUserToRole', userId, 'user' );
-  }
-});

--- a/client/modules/signup.js
+++ b/client/modules/signup.js
@@ -42,6 +42,8 @@ let _handleSignup = ( template ) => {
     if ( error ) {
       Bert.alert( error.reason, 'danger' );
     } else {
+      let userId = Meteor.userId();
+      Meteor.call( 'addUserToRole', userId, 'user' );
       Bert.alert( 'Welcome!', 'success' );
     }
   });

--- a/client/templates/admin/settings.html
+++ b/client/templates/admin/settings.html
@@ -1,0 +1,6 @@
+<template name="settings">
+  <div class="jumbotron text-center" style="padding: 20px;">
+    <h2>Manage your application</h2>
+    <p>A starting point for an administration panel.</p>
+  </div>
+</template>

--- a/client/templates/admin/settings.js
+++ b/client/templates/admin/settings.js
@@ -1,0 +1,3 @@
+Template.settings.onCreated( () => {
+  Template.instance().subscribe( 'template' );
+});

--- a/client/templates/globals/admin-navigation.html
+++ b/client/templates/globals/admin-navigation.html
@@ -1,0 +1,5 @@
+<template name="adminNavigation">
+  <ul class="nav navbar-nav">
+    <li class="{{currentRoute 'settings'}}"><a href="{{pathFor 'settings'}}">Settings</a></li>
+  </ul>
+</template>

--- a/client/templates/globals/header.html
+++ b/client/templates/globals/header.html
@@ -13,6 +13,9 @@
 	    <div id="navbar-collapse" class="collapse navbar-collapse">
 	    	{{#if currentUser}}
 					{{> authenticatedNavigation}}
+          {{#if isInRole 'admin'}}
+            {{> adminNavigation}}
+          {{/if}}
 	      {{else}}
 	      	{{> publicNavigation}}
 	      {{/if}}

--- a/client/templates/layouts/default.js
+++ b/client/templates/layouts/default.js
@@ -14,17 +14,22 @@ Template.default.helpers({
 		return !Meteor.loggingIn() && Meteor.user();
 	},
 	redirectAuthenticated() {
-	 	return handleRedirect([
-			'login',
-			'signup',
-			'recover-password',
-			'reset-password'
-		], '/' );
+    let forbiddenRoutes = [
+      'login',
+      'signup',
+      'recover-password',
+      'reset-password'
+    ];
+    if ( !Roles.userIsInRole( Meteor.userId() , 'admin' ) ) {
+      forbiddenRoutes.push( 'settings' );
+    }
+	 	return handleRedirect( forbiddenRoutes, '/' );
 	},
 	redirectPublic() {
 		return handleRedirect([
 			'index',
-			'dashboard'
+			'dashboard',
+      'settings'
 		], '/login' );
 	}
 });

--- a/server/modules/generate-accounts.js
+++ b/server/modules/generate-accounts.js
@@ -46,9 +46,7 @@ let _createUser = ( user ) => {
     }
   });
 
-  if ( user.role !== undefined ) {
-    Roles.addUsersToRoles( userId, user.role );
-  }
+  Roles.addUsersToRoles( userId, user.role );
 };
 
 let _generateFakeUsers = ( count ) => {
@@ -58,7 +56,8 @@ let _generateFakeUsers = ( count ) => {
     users.push({
       name: { first: faker.name.firstName(), last: faker.name.lastName() },
       email: faker.internet.email(),
-      password: 'password'
+      password: 'password',
+      role: 'user'
     });
   }
 

--- a/server/modules/generate-accounts.js
+++ b/server/modules/generate-accounts.js
@@ -2,7 +2,8 @@ let administrators = [
   {
     name: { first: 'Admin', last: 'McAdmin' },
     email: 'admin@admin.com',
-    password: 'password'
+    password: 'password',
+    role: 'admin'
   }
 ];
 
@@ -37,13 +38,17 @@ let _checkIfUserExists = ( email ) => {
 };
 
 let _createUser = ( user ) => {
-  Accounts.createUser({
+  let userId = Accounts.createUser({
     email: user.email,
     password: user.password,
     profile: {
       name: user.name
     }
   });
+
+  if ( user.role !== undefined ) {
+    Roles.addUsersToRoles( userId, user.role );
+  }
 };
 
 let _generateFakeUsers = ( count ) => {


### PR DESCRIPTION
When generating the accounts on the first launch, the administrators
account has an ‘admin’ role set.
This allows them to access a group of routes name adminRoutes. The
redirection is based on the existing redirectHandler.
The admin nav is only shown if the user is in role admin.
It’s intended to be the start of an administrator panel (settings,
users, etc.)