### PR TITLE
Add Confirm dialog

### DIFF
--- a/imports/ui/components/confirm.js
+++ b/imports/ui/components/confirm.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import { Button, Modal } from 'react-bootstrap';
+
+if (typeof Global === 'undefined') {
+  Global = {};
+}
+
+export default class Confirm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      show: false,
+      message: '',
+      callback: null,
+    };
+
+    this.show = this.show.bind(this);
+    this.hide = this.hide.bind(this);
+  }
+
+  componentDidMount() {
+    Global.confirm = this.show;
+  }
+
+  show(message, callback) {
+    this.setState({
+      show: true,
+      message,
+      callback,
+    });
+  }
+
+  hide(response) {
+    this.setState({
+      show: false,
+    }, this.state.callback(response));
+  }
+
+  render() {
+    let { message, show } = this.state;
+
+    return (
+      <div className="static-modal">
+        <Modal show={show} onHide={this.hide}>
+          <Modal.Header>
+            <Modal.Title>Are you sure?</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            { message }
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={() => this.hide(false)}>
+              Cancel
+            </Button>
+            <Button bsStyle="primary" onClick={() => this.hide(true)}>
+              Okay
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}

--- a/imports/ui/components/document.js
+++ b/imports/ui/components/document.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Row, Col, ListGroupItem, FormControl, Button } from 'react-bootstrap';
 import { Bert } from 'meteor/themeteorchef:bert';
 import { updateDocument, removeDocument } from '../../api/documents/methods.js';
@@ -20,21 +20,21 @@ const handleUpdateDocument = (documentId, event) => {
 };
 
 const handleRemoveDocument = (documentId, event) => {
-  event.preventDefault();
-  // this should be replaced with a styled solution so for now we will
-  // disable the eslint `no-alert`
-  // eslint-disable-next-line no-alert
-  if (confirm('Are you sure? This is permanent.')) {
-    removeDocument.call({
-      _id: documentId,
-    }, (error) => {
-      if (error) {
-        Bert.alert(error.reason, 'danger');
-      } else {
-        Bert.alert('Document removed!', 'success');
-      }
-    });
-  }
+  Global.confirm('This is permanent.', (confirmed) => {
+    event.preventDefault();
+
+    if (confirmed) {
+      removeDocument.call({
+        _id: documentId,
+      }, (error) => {
+        if (error) {
+          Bert.alert(error.reason, 'danger');
+        } else {
+          Bert.alert('Document removed!', 'success');
+        }
+      });
+    }
+  });
 };
 
 export const Document = ({ document }) => (
@@ -59,3 +59,7 @@ export const Document = ({ document }) => (
     </Row>
   </ListGroupItem>
 );
+
+Document.propTypes = {
+  document: PropTypes.object.required,
+};

--- a/imports/ui/layouts/app.js
+++ b/imports/ui/layouts/app.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Grid } from 'react-bootstrap';
 import AppNavigation from '../containers/app-navigation';
+import Confirm from '../components/confirm';
 
 export const App = React.createClass({
   propTypes: {
@@ -9,6 +10,7 @@ export const App = React.createClass({
   render() {
     return <div>
       <AppNavigation />
+      <Confirm />
       <Grid>
         { this.props.children }
       </Grid>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "globals": {
       "server": false,
       "browser": false,
-      "expect": false
+      "expect": false,
+      "Global": true
     },
     "rules": {
       "import/no-unresolved": 0,


### PR DESCRIPTION
Adds a Confirm dialog component
Renders it in the layout
Calls it in `handleRemoveDocument`

Currently the `show` method is attached to a global variable `Global` (as `confirm`), a bit like how `Modules.client` worked in 3.0.

![image](https://cloud.githubusercontent.com/assets/357702/15785579/eb1cb130-29af-11e6-8edf-42167b24c3a3.png)

Closes #147.
