### PR TITLE
Added missing dependency: eslint-plugin-import & meteor-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chimp": "^0.39.1",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^1.5.5",
     "eslint-plugin-meteor": "^3.6.0",
     "eslint-plugin-react": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "bootstrap": "^3.3.7",
     "jquery": "^2.2.4",
     "jquery-validation": "^1.15.1",
+    "meteor-promise": "^0.7.3",
     "react": "^15.3.0",
     "react-addons-pure-render-mixin": "^15.2.1",
     "react-bootstrap": "^0.30.2",


### PR DESCRIPTION
Fixes:
npm ERR! missing: eslint-plugin-import@^1.7.0, required by eslint-config-airbnb-base@3.0.1
npm ERR! missing: eslint-plugin-import@^1.7.0, required by eslint-config-airbnb@9.0.1

Also, Chimp uses xolvio-sync-webdriverio which has an old dependency on meteor-promise for some reason:

```
λ meteor npm list meteor-promise
application-name@1.0.0 C:\Users\jeremy.fowler\Desktop\Projects\base
+-- chimp@0.39.4
| +-- cucumber@1.2.2 (git://github.com/xolvio/cucumber-js.git#ae7ae962abadcfa141c385ec815014c104250de1)
| | `-- meteor-promise@0.7.2
| `-- xolvio-sync-webdriverio@5.1.0
|   `-- meteor-promise@0.4.8
`-- meteor-promise@0.7.3
```

So, if we don't install a newer version of meteor-promise from npm,  we get this error:

```
W20160830-22:20:44.422(-5)? (STDERR) require("meteor-promise").makeCompatible(Promise, require("fibers"));
W20160830-22:20:44.423(-5)? (STDERR)                           ^
W20160830-22:20:44.424(-5)? (STDERR)
W20160830-22:20:44.425(-5)? (STDERR) TypeError: require(...).makeCompatible is not a function
W20160830-22:20:44.427(-5)? (STDERR)     at Object.<anonymous> (C:\Users\jeremy.fowler\Desktop\Projects\base\.meteor\local\build\p
rograms\server\shell-server.js:15:27)
W20160830-22:20:44.428(-5)? (STDERR)     at Module._compile (module.js:409:26)
W20160830-22:20:44.429(-5)? (STDERR)     at Object.Module._extensions..js (module.js:416:10)
W20160830-22:20:44.431(-5)? (STDERR)     at Module.load (module.js:343:32)
W20160830-22:20:44.443(-5)? (STDERR)     at Function.Module._load (module.js:300:12)
W20160830-22:20:44.445(-5)? (STDERR)     at Module.require (module.js:353:17)
W20160830-22:20:44.446(-5)? (STDERR)     at require (internal/module.js:12:17)
W20160830-22:20:44.447(-5)? (STDERR)     at Object.<anonymous> (C:\Users\jeremy.fowler\Desktop\Projects\base\.meteor\local\build\p
rograms\server\boot.js:101:3)
W20160830-22:20:44.448(-5)? (STDERR)     at Module._compile (module.js:409:26)
W20160830-22:20:44.449(-5)? (STDERR)     at Object.Module._extensions..js (module.js:416:10)
```
