### PR TITLE
Change icon hrefs to the root level.

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -3,8 +3,8 @@
   <title>Application Name</title>
   <meta name="description" content="A description for the application.">
   <meta name="viewport" content="initial-scale=1, minimal-ui, maximum-scale=1, minimum-scale=1" />
-  <link rel="shortcut icon" type="image/png" href="favicon.png?v1" sizes="16x16 32x32 64x64">
-  <link rel="apple-touch-icon" sizes="120x120" href="apple-touch-icon-precomposed.png">
+  <link rel="shortcut icon" type="image/png" href="/favicon.png?v1" sizes="16x16 32x32 64x64">
+  <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-precomposed.png">
 </head>
 
 <body>


### PR DESCRIPTION
When navigating to a page such as /documents/new the favicon was not available as this file was referencing the image /documents/favicon.png which does not exist.