### PR TITLE
Destructuring function parameter throws TypeError

### DIFF
--- a/imports/modules/document-editor.js
+++ b/imports/modules/document-editor.js
@@ -17,13 +17,13 @@ const handleUpsert = () => {
 
   if (doc && doc._id) upsert._id = doc._id;
 
-  upsertDocument.call(upsert, (error, { insertedId }) => {
+  upsertDocument.call(upsert, (error, response) => {
     if (error) {
       Bert.alert(error.reason, 'danger');
     } else {
       component.documentEditorForm.reset();
       Bert.alert(confirmation, 'success');
-      browserHistory.push(`/documents/${insertedId || doc._id}`);
+      browserHistory.push(`/documents/${response.insertedId || doc._id}`);
     }
   });
 };


### PR DESCRIPTION
In the `document-editor.js` module, the `upsertDocument.call` destructures the second parameter. The second parameter will be undefined on an error and throw a TypeError rather than allowing the error parameter to be passed to the function and handled by Bert. I have changed the second parameter to a regular variable and refer to `insertedId` later using `response.insertedId`.
This can be tested by changing the required type in the schema file and then passing in the wrong type through the form.