### PR TITLE
Fixed wrong name for reset password form validation

### DIFF
--- a/imports/modules/reset-password.js
+++ b/imports/modules/reset-password.js
@@ -21,7 +21,7 @@ const handleReset = () => {
 };
 
 const validate = () => {
-  $(component.resetPassword).validate({
+  $(component.resetPasswordForm).validate({
     rules: {
       newPassword: {
         required: true,


### PR DESCRIPTION
Reset password form is not being validated and submission doesn't work because it has wrong name of the form component