### PR TITLE
Remove Auth on Index route

### DIFF
--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -29,7 +29,7 @@ Meteor.startup(() => {
   render(
     <Router history={ browserHistory }>
       <Route path="/" component={ App }>
-        <IndexRoute name="index" component={ Index } onEnter={ authenticate } />
+        <IndexRoute name="index" component={ Index } />
         <Route name="documents" path="/documents" component={ Documents } onEnter={ authenticate } />
         <Route name="newDocument" path="/documents/new" component={ NewDocument } onEnter={ authenticate } />
         <Route name="editDocument" path="/documents/:_id/edit" component={ EditDocument } onEnter={ authenticate } />


### PR DESCRIPTION
Removed authorisation onEnter for Index route to prevent redirect to login.

Was preventing loading of index route without being logged in. If Base was being used for a SaaS, access to the landing page would be an essential part of marketing/functionality for new users.

Not sure if this was put there for a reason but I find myself having to remove it every time I clone Base for a project.