### PR TITLE
Add Top Level Name Field

### DIFF
--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+
+Meteor.publish('users.info', () => Meteor.users.find({}, {
+  fields: {
+    name: 1,
+  },
+}));

--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -1,7 +1,13 @@
 import { Meteor } from 'meteor/meteor';
 
-Meteor.publish('users.info', () => Meteor.users.find({}, {
-  fields: {
-    name: 1,
-  },
-}));
+Meteor.publish('users.info', function userInfoPublish() {
+  if (!this.userId) {
+    return this.ready();
+  }
+
+  return Meteor.users.find({}, {
+    fields: {
+      name: 1,
+    },
+  });
+});

--- a/imports/api/users/server/publications.js
+++ b/imports/api/users/server/publications.js
@@ -5,7 +5,7 @@ Meteor.publish('users.info', function userInfoPublish() {
     return this.ready();
   }
 
-  return Meteor.users.find({}, {
+  return Meteor.users.find(this.userId, {
     fields: {
       name: 1,
     },

--- a/imports/startup/server/accounts/on-create-user.js
+++ b/imports/startup/server/accounts/on-create-user.js
@@ -1,0 +1,12 @@
+import { Accounts } from 'meteor/accounts-base';
+
+Accounts.onCreateUser((options, user) => {
+  const profile = options.profile;
+  const newUser = user;
+
+  if (profile) {
+    newUser.name = { first: profile.name.first, last: profile.name.last };
+  }
+
+  return newUser;
+});

--- a/imports/startup/server/api.js
+++ b/imports/startup/server/api.js
@@ -1,2 +1,3 @@
 import '../../api/documents/methods.js';
 import '../../api/documents/server/publications.js';
+import '../../api/users/server/publications.js';

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -1,4 +1,5 @@
 import './accounts/email-templates';
+import './accounts/on-create-user';
 import './browser-policy';
 import './fixtures';
 import './api';

--- a/imports/ui/components/AuthenticatedNavigation.js
+++ b/imports/ui/components/AuthenticatedNavigation.js
@@ -8,7 +8,7 @@ const handleLogout = () => Meteor.logout(() => browserHistory.push('/login'));
 
 const userName = () => {
   const user = Meteor.user();
-  const name = user && user.profile ? user.profile.name : '';
+  const name = user ? user.name : '';
   return user ? `${name.first} ${name.last}` : '';
 };
 

--- a/imports/ui/containers/AppNavigation.js
+++ b/imports/ui/containers/AppNavigation.js
@@ -1,7 +1,13 @@
 import { composeWithTracker } from 'react-komposer';
 import { Meteor } from 'meteor/meteor';
 import AppNavigation from '../components/AppNavigation.js';
+import Loading from '../components/Loading.js';
 
-const composer = (props, onData) => onData(null, { hasUser: Meteor.user() });
+const composer = (params, onData) => {
+  const subscription = Meteor.subscribe('users.info');
+  if (subscription.ready()) {
+    onData(null, { hasUser: Meteor.user() });
+  }
+};
 
-export default composeWithTracker(composer, {}, {}, { pure: false })(AppNavigation);
+export default composeWithTracker(composer, Loading, {}, { pure: false })(AppNavigation);


### PR DESCRIPTION
Per https://guide.meteor.com/accounts.html#dont-use-profile, profile shouldn't really be used. This request refactors the name field to be a top level field and demonstrates how the user collection could be used more securely. 